### PR TITLE
try to load user's prettier-eslint first before falling back to a bundled one

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
         "vscode": "^1.1.0"
     },
     "dependencies": {
-        "prettier-eslint": "^5.1.0"
+        "prettier-eslint": "^5.1.0",
+        "require-relative": "^0.8.7"
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import {
     workspace
 } from 'vscode';
 
-const formatPrettierESLint = require('prettier-eslint');
+const requireRelative = require('require-relative');
 
 let statusbar: StatusBarItem = undefined;
 let outputHandler: Function = () => { };
@@ -48,6 +48,7 @@ const getPath = (path) => {
 
 export function format(text: string = '', filePath: string) {
     try {
+        const formatPrettierESLint = requirePrettierEslint(filePath);
         const prettierOptions = workspace.getConfiguration('prettier') as any;
         const prettierEslintOptions = workspace.getConfiguration('prettier-eslint') as any;
 
@@ -93,4 +94,12 @@ export function formatDocument(validLanguages: any, document: TextDocument, edit
                 format(document.getText(selection), document.fileName)
             ));
     }));
+}
+
+function requirePrettierEslint(filePath: string) {
+    try {
+        return requireRelative('prettier-eslint', filePath);
+    } catch (err) {
+        return require('prettier-eslint');
+    }
 }


### PR DESCRIPTION
Also #18 
It tries to find `prettier-eslint` relative to the edited file first.